### PR TITLE
fix(index.js): make it work with babel 6.22

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ export default function () {
         let callee = path.get("callee");
         let args   = path.get("arguments");
 
-        if (!callee.matchesPattern("import") ||
+        if (callee.type !== 'Import' ||
             !args.length) return;
 
         path.scope.rename("require");


### PR DESCRIPTION
For me `callee.matchesPattern('import')` doesn't work with babel 6.22, but this change does.  I don't really know what's changed in babel.  Do you have any idea?